### PR TITLE
Bugfix: Using the new string.format() method

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -121,7 +121,7 @@ def lambda_handler(event, context):
     if total_wlm_queue_time == None:
         total_wlm_queue_time = 0
 
-    run_command(cursor,"SELECT /* Lambda CloudWatch Exporter */ count(distinct query) FROM svl_query_report WHERE is_diskbased='t' AND (LABEL LIKE 'hash%%' OR LABEL LIKE 'sort%%' OR LABEL LIKE 'aggr%%') AND userid > 1 AND start_time >= GETDATE() - INTERVAL '%s'" % interval)
+    run_command(cursor,"SELECT /* Lambda CloudWatch Exporter */ count(distinct query) FROM svl_query_report WHERE is_diskbased='t' AND (LABEL LIKE 'hash%%' OR LABEL LIKE 'sort%%' OR LABEL LIKE 'aggr%%') AND userid > 1 AND start_time >= GETDATE() - INTERVAL '{0}'".format(interval))
     total_disk_based_queries = cursor.fetchone()[0]
     if total_disk_based_queries == None:
         total_disk_based_queries = 0


### PR DESCRIPTION
Running the script results in an error from pg8000 like below 

pg8000.core.InterfaceError: '%'' not supported in a quoted string within the query string

This is because pg8000 seems to do some sort of % based replacement again, and that seems to cause an issue. Therefore switching to newer format method so that the %% is retained and when pg8000 encounters the % it doesn't complain. 

Additionally, the old "%" based formatting is on the path to deprecation - http://docs.python.org/tutorial/inputoutput.html#fancier-output-formatting