### PR TITLE
set_debug bug

### DIFF
--- a/redshift_monitoring.py
+++ b/redshift_monitoring.py
@@ -314,10 +314,6 @@ def monitor_cluster(config_sources):
     cluster = get_config_value(['ClusterName', 'cluster_name', 'clusterName'], config_sources)
     global interval
     interval = get_config_value(['AggregationInterval', 'agg_interval', 'aggregtionInterval'], config_sources)
-    set_debug = get_config_value(['debug','DEBUG'], config_sources)
-    if set_debug is not None:
-        global debug
-        debug = set_debug
 
 
     # decrypt the password

--- a/redshift_monitoring.py
+++ b/redshift_monitoring.py
@@ -295,6 +295,10 @@ def get_encryption_context(cmk, region):
 def monitor_cluster(config_sources):
     aws_region = get_config_value(['AWS_REGION'], config_sources)
 
+    if str(get_config_value(['DEBUG', 'debug', ], config_sources)).upper() == 'TRUE':
+        global debug
+        debug = True
+
     kms = boto3.client('kms', region_name=aws_region)
     cw = boto3.client('cloudwatch', region_name=aws_region)
 
@@ -313,10 +317,8 @@ def monitor_cluster(config_sources):
     set_debug = get_config_value(['debug','DEBUG'], config_sources)
     if set_debug is not None:
         global debug
-        if get_config_value(['DEBUG', 'debug', ], config_sources).upper() == 'TRUE':
-            debug = True
-        else:
-            debug = False
+        debug = set_debug
+
 
     # decrypt the password
     auth_context = None

--- a/redshift_monitoring.py
+++ b/redshift_monitoring.py
@@ -295,10 +295,6 @@ def get_encryption_context(cmk, region):
 def monitor_cluster(config_sources):
     aws_region = get_config_value(['AWS_REGION'], config_sources)
 
-    if get_config_value(['DEBUG', 'debug', ], config_sources).upper() == 'TRUE':
-        global debug
-        debug = True
-
     kms = boto3.client('kms', region_name=aws_region)
     cw = boto3.client('cloudwatch', region_name=aws_region)
 
@@ -317,7 +313,10 @@ def monitor_cluster(config_sources):
     set_debug = get_config_value(['debug','DEBUG'], config_sources)
     if set_debug is not None:
         global debug
-        debug = set_debug
+        if get_config_value(['DEBUG', 'debug', ], config_sources).upper() == 'TRUE':
+            debug = True
+        else:
+            debug = False
 
     # decrypt the password
     auth_context = None


### PR DESCRIPTION
In cases where debug is not assigned we error with:

```
'NoneType' object has no attribute 'upper': AttributeError
Traceback (most recent call last):
File "/var/task/lambda_function.py", line 15, in lambda_handler
redshift_monitoring.monitor_cluster(config_sources)
File "/var/task/redshift_monitoring.py", line 298, in monitor_cluster
if get_config_value(['DEBUG', 'debug', ], config_sources).upper() == 'TRUE':
AttributeError: 'NoneType' object has no attribute 'upper'
```
This patch only attempts to check the string value of the debug config value in cases where it is defined, so as to avoid the UPPER call on a NoneType.