### PR TITLE
removing duplicate check for debug mode

### DIFF
--- a/redshift_monitoring.py
+++ b/redshift_monitoring.py
@@ -260,10 +260,6 @@ def monitor_cluster(config_sources):
     cluster = get_config_value(['ClusterName', 'cluster_name', 'clusterName'], config_sources)
     global interval
     interval = get_config_value(['AggregationInterval', 'agg_interval', 'aggregtionInterval'], config_sources)
-    set_debug = get_config_value(['debug', 'DEBUG'], config_sources)
-    if set_debug is not None:
-        global debug
-        debug = set_debug
     
     pwd = None
     try:


### PR DESCRIPTION
*Removing duplicate code to check debug mode based on config based*
First Instance of  [checking for debug mode](https://github.com/awslabs/amazon-redshift-monitoring/blob/118cf1633873d620b0781bb8ddcf464ed786bb6e/redshift_monitoring.py#L245-L248) in the function monitor_cluster() checks the type of value passed in the config_sources object and sets it appropriately.
The removed lines of code checks for debug mode after it has been set, and referenced already. Hence the code is redundant not serving any purpose.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
