### PR TITLE
fix KmsArnPattern and lambda runtime

### DIFF
--- a/deploy-vpc.yaml
+++ b/deploy-vpc.yaml
@@ -17,10 +17,10 @@ Parameters:
     Type: String
     AllowedPattern: .*
   KmsKeyARN:
-    Default: arn:aws:kms:us-east-1/123456789012:key/MyKey
+    Default: arn:aws:kms:us-east-1:123456789012:key/MyKey
     Description: KMS Key ARN used to decrypt the password
     Type: String
-    AllowedPattern: arn:aws:kms:[a-zA-Z0-9-]+\/\d{12}:key\/.*
+    AllowedPattern: arn:aws:kms:[a-zA-Z0-9-]+\:\d{12}:key\/.*
   HostName:
     Default: my-redshift-cluster.XXXXXXXXXXXX.<region>.redshift.amazonaws.com
     Description: Cluster Endpoint Address
@@ -57,7 +57,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: lambda_function.lambda_handler
-      Runtime: python3
+      Runtime: python3.6
       CodeUri:         
         Bucket: !Sub awslabs-code-${AWS::Region}
         Key: RedshiftAdvancedMonitoring/redshift-advanced-monitoring-1.6.zip


### PR DESCRIPTION
*Issue #, if available:*
1. KMS arn pattern error. In the "deploy-vpc.yaml", the patter would allow arns like "arn:aws:kms:us-east-1/123456789012:key/MyKey". However, the valid arn should be "arn:aws:kms:us-east-1:123456789012:key/MyKey"

2. Value python3 at 'runtime' failed to satisfy constraint. Using the default value, the page would return error: Member must satisfy enum value set: [java8, java11, nodejs10.x, nodejs12.x, python2.7, python3.6, python3.7, python3.8, dotnetcore2.1, go1.x, ruby2.5] or be a valid ARN (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: c6a94b9d-9f35-457b-9daf-fa2432a0a63f

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the

 terms of your choice.
