### PR TITLE
Add IAM database authentication token support

### DIFF
--- a/deploy-non-vpc.yaml
+++ b/deploy-non-vpc.yaml
@@ -44,6 +44,11 @@ Parameters:
     AllowedValues:
       - 1 hour
       - 10 minutes
+Conditions:
+  UseKms: !Not
+   - !Equals
+     - !Ref KmsKeyARN
+     - ''
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function
@@ -126,4 +131,6 @@ Resources:
             Effect: "Allow"
             Action:
               - "redshift:GetClusterCredentials"
-            Resource: !Sub "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterName}/${DbUser}"
+            Resource:
+              - !Sub "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbname:${ClusterName}/${DatabaseName}"
+              - !Sub "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterName}/${DbUser}"

--- a/deploy-non-vpc.yaml
+++ b/deploy-non-vpc.yaml
@@ -15,7 +15,7 @@ Parameters:
     Default: arn:aws:kms:us-east-1:123456789012:key/MyKey
     Description: KMS Key ARN used to decrypt the password (leave blank to use IAM authentication token)
     Type: String
-    AllowedPattern: arn:aws:kms:[a-zA-Z0-9-]+:\d{12}:key\/.*
+    AllowedPattern: ^$|arn:aws:kms:[a-zA-Z0-9-]+:\d{12}:key\/.*
   EncryptedPassword:
     Default: Base64 Encoded Encrypted Password
     Description: Password encrypted with AWS KMS (leave blank to use IAM authentication token)

--- a/deploy-non-vpc.yaml
+++ b/deploy-non-vpc.yaml
@@ -11,16 +11,16 @@ Parameters:
     Description: Name of the database user to connect to
     Type: String
     AllowedPattern: .*
-  KmsKeyARN:
-    Default: arn:aws:kms:us-east-1:123456789012:key/MyKey
-    Description: KMS Key ARN used to decrypt the password (leave blank to use IAM authentication token)
-    Type: String
-    AllowedPattern: ^$|arn:aws:kms:[a-zA-Z0-9-]+:\d{12}:key\/.*
   EncryptedPassword:
     Default: Base64 Encoded Encrypted Password
     Description: Password encrypted with AWS KMS (leave blank to use IAM authentication token)
     Type: String
     AllowedPattern: .*
+  KmsKeyARN:
+    Default: arn:aws:kms:us-east-1:123456789012:key/MyKey
+    Description: KMS Key ARN used to decrypt the password (leave blank to use IAM authentication token)
+    Type: String
+    AllowedPattern: ^$|arn:aws:kms:[a-zA-Z0-9-]+:\d{12}:key\/.*
   HostName:
     Default: my-redshift-cluster.XXXXXXXXXXXX.<region>.redshift.amazonaws.com
     Description: Cluster Endpoint Address
@@ -79,8 +79,6 @@ Resources:
     Properties:
         RoleName: "LambdaRedshiftMonitoringRole"
         Path: "/"
-        ManagedPolicyArns:
-            - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         AssumeRolePolicyDocument:
           Version: "2012-10-17"
           Statement:
@@ -101,10 +99,31 @@ Resources:
                 -
                   Effect: "Allow"
                   Action:
-                    - "cloudwatch:PutMetricData"                    
+                    - "cloudwatch:PutMetricData"
                   Resource: "*"
-                -
-                  Effect: "Allow"
-                  Action:                
-                    - "kms:Decrypt"
-                  Resource: !Ref KmsKeyARN
+        ManagedPolicyArns:
+          - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+          - !If [UseKms, !Ref KmsDecryptPolicy, !Ref GetClusterCredentialsPolicy]
+  KmsDecryptPolicy:
+    Condition: UseKms
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action:
+              - "kms:Decrypt"
+            Resource: !Ref KmsKeyARN
+  GetClusterCredentialsPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action:
+              - "redshift:GetClusterCredentials"
+            Resource: !Sub "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterName}/${DbUser}"

--- a/deploy-non-vpc.yaml
+++ b/deploy-non-vpc.yaml
@@ -13,12 +13,12 @@ Parameters:
     AllowedPattern: .*
   KmsKeyARN:
     Default: arn:aws:kms:us-east-1:123456789012:key/MyKey
-    Description: KMS Key ARN used to decrypt the password
+    Description: KMS Key ARN used to decrypt the password (leave blank to use IAM authentication token)
     Type: String
     AllowedPattern: arn:aws:kms:[a-zA-Z0-9-]+:\d{12}:key\/.*
   EncryptedPassword:
     Default: Base64 Encoded Encrypted Password
-    Description: Password encrypted with AWS KMS
+    Description: Password encrypted with AWS KMS (leave blank to use IAM authentication token)
     Type: String
     AllowedPattern: .*
   HostName:

--- a/deploy-vpc.yaml
+++ b/deploy-vpc.yaml
@@ -13,12 +13,12 @@ Parameters:
     AllowedPattern: .*
   EncryptedPassword:
     Default: Base64 Encoded Encrypted Password
-    Description: Password encrypted with AWS KMS
+    Description: Password encrypted with AWS KMS (leave blank to use IAM authentication token)
     Type: String
     AllowedPattern: .*
   KmsKeyARN:
     Default: arn:aws:kms:us-east-1:123456789012:key/MyKey
-    Description: KMS Key ARN used to decrypt the password
+    Description: KMS Key ARN used to decrypt the password (leave blank to use IAM authentication token)
     Type: String
     AllowedPattern: arn:aws:kms:[a-zA-Z0-9-]+:\d{12}:key\/.*
   HostName:

--- a/deploy-vpc.yaml
+++ b/deploy-vpc.yaml
@@ -20,7 +20,7 @@ Parameters:
     Default: arn:aws:kms:us-east-1:123456789012:key/MyKey
     Description: KMS Key ARN used to decrypt the password (leave blank to use IAM authentication token)
     Type: String
-    AllowedPattern: arn:aws:kms:[a-zA-Z0-9-]+:\d{12}:key\/.*
+    AllowedPattern: ^$|arn:aws:kms:[a-zA-Z0-9-]+:\d{12}:key\/.*
   HostName:
     Default: my-redshift-cluster.XXXXXXXXXXXX.<region>.redshift.amazonaws.com
     Description: Cluster Endpoint Address

--- a/deploy-vpc.yaml
+++ b/deploy-vpc.yaml
@@ -144,4 +144,6 @@ Resources:
             Effect: "Allow"
             Action:
               - "redshift:GetClusterCredentials"
-            Resource: !Sub "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterName}/${DbUser}"
+            Resource: 
+              - !Sub "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbname:${ClusterName}/${DatabaseName}"
+              - !Sub "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterName}/${DbUser}"

--- a/deploy-vpc.yaml
+++ b/deploy-vpc.yaml
@@ -123,6 +123,7 @@ Resources:
           - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
           - !If [UseKms, !Ref KmsDecryptPolicy, !Ref GetClusterCredentialsPolicy]
   KmsDecryptPolicy:
+    Condition: UseKms
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
       PolicyDocument:

--- a/deploy-vpc.yaml
+++ b/deploy-vpc.yaml
@@ -52,6 +52,11 @@ Parameters:
     AllowedValues:
       - 1 hour
       - 10 minutes
+Conditions:
+  UseKms: !Not
+   - !Equals
+     - !Ref KmsKeyARN
+     - ''
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function
@@ -92,8 +97,6 @@ Resources:
     Properties:
         RoleName: "LambdaRedshiftMonitoringRole"
         Path: "/"
-        ManagedPolicyArns:
-            - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         AssumeRolePolicyDocument:
           Version: "2012-10-17"
           Statement:
@@ -116,8 +119,28 @@ Resources:
                   Action:
                     - "cloudwatch:PutMetricData"
                   Resource: "*"
-                -
-                  Effect: "Allow"
-                  Action:                
-                    - "kms:Decrypt"
-                  Resource: !Ref KmsKeyARN
+        ManagedPolicyArns:
+          - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+          - !If [UseKms, !Ref KmsDecryptPolicy, !Ref GetClusterCredentialsPolicy]
+  KmsDecryptPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action:
+              - "kms:Decrypt"
+            Resource: !Ref KmsKeyARN
+  GetClusterCredentialsPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action:
+              - "redshift:GetClusterCredentials"
+            Resource: !Sub "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterName}/${DbUser}"

--- a/redshift_monitoring.py
+++ b/redshift_monitoring.py
@@ -250,6 +250,7 @@ def monitor_cluster(config_sources):
 
     kms = boto3.client('kms', region_name=aws_region)
     cw = boto3.client('cloudwatch', region_name=aws_region)
+    redshift = boto3.client('redshift', region_name=aws_region)
 
     if debug:
         print("Connected to AWS KMS & CloudWatch in %s" % aws_region)
@@ -259,9 +260,10 @@ def monitor_cluster(config_sources):
     port = int(get_config_value(['HostPort', 'db_port', 'dbPort'], config_sources))
     database = get_config_value(['DatabaseName', 'db_name', 'db'], config_sources)
     cluster = get_config_value(['ClusterName', 'cluster_name', 'clusterName'], config_sources)
+
     global interval
     interval = get_config_value(['AggregationInterval', 'agg_interval', 'aggregtionInterval'], config_sources)
-    
+
     pwd = None
     try:
         pwd = pgpasslib.getpass(host, port, database, user)
@@ -276,24 +278,38 @@ def monitor_cluster(config_sources):
     if pwd is None:
         enc_password = get_config_value(['EncryptedPassword', 'encrypted_password', 'encrypted_pwd', 'dbPassword'],
                                         config_sources)
-        # resolve the authorisation context, if there is one, and decrypt the password
-        auth_context = get_config_value('kms_auth_context', config_sources)
+        if enc_password is not None:
 
-        if auth_context is not None:
-            auth_context = json.loads(auth_context)
+            # resolve the authorisation context, if there is one, and decrypt the password
+            auth_context = get_config_value('kms_auth_context', config_sources)
 
+            if auth_context is not None:
+                auth_context = json.loads(auth_context)
+
+            try:
+                if auth_context is None:
+                    pwd = kms.decrypt(CiphertextBlob=base64.b64decode(enc_password))[
+                        'Plaintext']
+                else:
+                    pwd = kms.decrypt(CiphertextBlob=base64.b64decode(enc_password), EncryptionContext=auth_context)[
+                        'Plaintext']
+            except:
+                print('KMS access failed: exception %s' % sys.exc_info()[1])
+                print('Encrypted Password: %s' % enc_password)
+                print('Encryption Context %s' % auth_context)
+
+    # check for credentials using IAM database authentication
+    if pwd is None:
         try:
-            if auth_context is None:
-                pwd = kms.decrypt(CiphertextBlob=base64.b64decode(enc_password))[
-                    'Plaintext']
-            else:
-                pwd = kms.decrypt(CiphertextBlob=base64.b64decode(enc_password), EncryptionContext=auth_context)[
-                    'Plaintext']
+            cluster_credentials = redshift_client.get_cluster_credentials(DbUser=user,
+                                                                          DbName=database,
+                                                                          ClusterIdentifier=cluster,
+                                                                          AutoCreate=False)
+            user = cluster_credentials['DbUser']
+            pwd = cluster_credentials['DbPassword']
+
         except:
-            print('KMS access failed: exception %s' % sys.exc_info()[1])
-            print('Encrypted Password: %s' % enc_password)
-            print('Encryption Context %s' % auth_context)
-            raise
+            print('GetClusterCredentials failed: exception %s' % sys.exc_info()[1])
 
     # Connect to the cluster
     try:

--- a/redshift_monitoring.py
+++ b/redshift_monitoring.py
@@ -278,7 +278,7 @@ def monitor_cluster(config_sources):
     if pwd is None:
         enc_password = get_config_value(['EncryptedPassword', 'encrypted_password', 'encrypted_pwd', 'dbPassword'],
                                         config_sources)
-        if enc_password is not None:
+        if enc_password:
 
             # resolve the authorisation context, if there is one, and decrypt the password
             auth_context = get_config_value('kms_auth_context', config_sources)

--- a/redshift_monitoring.py
+++ b/redshift_monitoring.py
@@ -301,7 +301,7 @@ def monitor_cluster(config_sources):
     # check for credentials using IAM database authentication
     if pwd is None:
         try:
-            cluster_credentials = redshift_client.get_cluster_credentials(DbUser=user,
+            cluster_credentials = redshift.get_cluster_credentials(DbUser=user,
                                                                           DbName=database,
                                                                           ClusterIdentifier=cluster,
                                                                           AutoCreate=False)


### PR DESCRIPTION
*Issue #, if available:* #6

*Description of changes:*
- Add [IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) token support using GetClusterCredentials
- Update deploy YAML to include 'leave blank to use IAM authentication token', referencing token support

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
